### PR TITLE
Add AT&T Submission #2 result to Single-Model Leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3311,6 +3311,21 @@
 
                     <tr>
                       <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Nov 11, 2024</span>
+                      </td>
+                      <td class="align-middle text-center">AskData/DSAIR + GPT-4o<br>
+                        <span class="affiliation">AT&T CDO</span>
+                        <br><a href="https://arxiv.org/abs/2505.19988" class="paperlink">[Shkapenyuk et al. '25]</a>
+                      </td>
+                      <td class="align-middle text-center"></td>
+                      <td class="align-middle text-center">UNK</td>
+                      <td class="align-middle text-center" style="font-size: 0.95em; font-style: italic;">Few</td>
+                      <td class="align-middle text-center">74.32</td>
+                      <td class="align-middle text-center"><b>74.12</b></td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
                         <span class="badge badge-secondary">May 07, 2025</span>
                       </td>
                       <td class="align-middle text-center">Arctic-Text2SQL-R1-32B<br>


### PR DESCRIPTION
In November 2024 you tested AT&T submission #2 (DSAIR + GPT-4o) which achieved an EX score of 74.12 on BIRD test dataset. We removed this result from the leaderboard webpage since it has been superseded by the results from AT&T submission #3 (current SOTA).
 
We noticed that there is a new category on BIRD leaderboard – single-model results. Our submission #2 falls into that category since it only used GPT-4o model and only used 3 candidates for self-consistency.  We would like to place the results from submission #2 back on the leaderboard under single-model category. No new testing is required since this is just a republishing of the old results.

Link to old PR for AT&T Submission#2:
https://github.com/bird-bench/bird-bench.github.io/pull/61
