### PR TITLE
Update DeepEye-SQL results for 27B model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,6 +1074,20 @@
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Jul 10, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">DeepEye-SQL<br>
+                      <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
+                    </td>
+                    <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
+                    <td class="align-middle text-center">Qwen3.6-27B</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">78.42</td>
+                  </tr>
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Jun 09, 2026</span>
                     </td>
                     <td class="align-middle text-center">DataGallery-Text2SQL<br>
@@ -1351,20 +1365,6 @@
                     <td class="align-middle text-center">77.10</td>
                     <td class="align-middle text-center">75.13</td>
                   </tr>
-                  <tr>
-                    <td scope="row" class="align-middle text-center counter-cell">
-                      <span class="badge badge-secondary">Oct 20, 2025</span>
-                    </td>
-                    <td class="align-middle text-center">DeepEye-SQL<br>
-                      <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
-                    </td>
-                    <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
-                    <td class="align-middle text-center">3B-MOE</td>
-                    <td class="align-middle text-center">✔️</td>
-                    <td class="align-middle text-center">73.53</td>
-                    <td class="align-middle text-center">75.07</td>
-                  </tr>
-
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Oct 30, 2025</span>
@@ -3207,6 +3207,19 @@
 
                     <tr>
                       <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Jul 10, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">DeepEye-SQL<br>
+                        <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
+                      <td class="align-middle text-center">Qwen3.6-27B</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">72.26</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
                         <span class="badge badge-secondary">Apr 28, 2026</span>
                       </td>
                       <td class="align-middle text-center">SiriusAI-Text2SQL-Agent<br>
@@ -3440,19 +3453,6 @@
                       <td class="align-middle text-center">UNK</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">69.32</td>
-                    </tr>
-
-                    <tr>
-                      <td scope="row" class="align-middle text-center counter-cell">
-                        <span class="badge badge-secondary">Oct 20, 2025</span>
-                      </td>
-                      <td class="align-middle text-center">DeepEye-SQL<br>
-                        <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
-                      </td>
-                      <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
-                      <td class="align-middle text-center">3B-MOE</td>
-                      <td class="align-middle text-center">✔️</td>
-                      <td class="align-middle text-center">68.82</td>
                     </tr>
 
                     <tr>

--- a/index.html
+++ b/index.html
@@ -1080,9 +1080,9 @@
                       <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
                     </td>
                     <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
-                    <td class="align-middle text-center">Qwen3.6-27B</td>
+                    <td class="align-middle text-center">27B</td>
                     <td class="align-middle text-center">✔️</td>
-                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">74.49</td>
                     <td class="align-middle text-center">78.42</td>
                   </tr>
 
@@ -3213,7 +3213,7 @@
                         <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
                       </td>
                       <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
-                      <td class="align-middle text-center">Qwen3.6-27B</td>
+                      <td class="align-middle text-center">27B</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">72.26</td>
                     </tr>


### PR DESCRIPTION
## Summary

- Update the DeepEye-SQL 27B entry to display `27B` in the parameter column.
- Set the EX scores to `74.49` on Dev and `78.42` on Test.
- Add the R-VES Test score of `72.26`.
- Remove the previous DeepEye-SQL `3B-MOE` entries.

## Validation

- `git diff --check`
- Verified the updated HTML contains two July 10, 2026 DeepEye-SQL rows with `27B` and no DeepEye-SQL `3B-MOE` rows.
