### PR TITLE
Add DeepEye leaderboard results

### DIFF
--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,20 @@
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Jul 14, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">DeepEye<br>
+                      <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/pdf/2603.28889" class="paperlink">[Boyan Li et al. '26]</a>
+                    </td>
+                    <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye">[link]</a></td>
+                    <td class="align-middle text-center">UNK</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">74.49</td>
+                    <td class="align-middle text-center">79.09</td>
+                  </tr>
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Jul 04, 2026</span>
                     </td>
                     <td class="align-middle text-center">MarkovSQL<br>
@@ -3401,6 +3415,19 @@
                       <td class="align-middle text-center">UNK</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">69.94</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Jul 14, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">DeepEye<br>
+                        <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/pdf/2603.28889" class="paperlink">[Boyan Li et al. '26]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye">[link]</a></td>
+                      <td class="align-middle text-center">UNK</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">69.85</td>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
## Summary

- Add a new `DeepEye` entry to the EX leaderboard with model size `UNK`, Dev EX `74.49`, and Test EX `79.09`.
- Add the corresponding R-VES Test score of `69.85`.
- Link the new paper and code repository.

## Validation

- `git diff --check`
- Confirmed the change contains 27 additions and no deletions.
- Verified both new rows use the requested name, links, scores, and `UNK` model size.