### PR TITLE
Fix DeepEye-SQL leaderboard ranking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1086,6 +1086,20 @@
                     <td class="align-middle text-center">78.70</td>
                   </tr>
 
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Jul 10, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">DeepEye-SQL<br>
+                      <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
+                    </td>
+                    <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
+                    <td class="align-middle text-center">27B</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">74.49</td>
+                    <td class="align-middle text-center">78.42</td>
+                  </tr>
+
 				  <tr>
 				    <td scope="row" class="align-middle text-center counter-cell">
 					  <span class="badge badge-secondary">Jul 11, 2026</span>
@@ -1104,20 +1118,6 @@
 					<td class="align-middle text-center">78.31</td>
 				  </tr>
 		
-                  <tr>
-                    <td scope="row" class="align-middle text-center counter-cell">
-                      <span class="badge badge-secondary">Jul 10, 2026</span>
-                    </td>
-                    <td class="align-middle text-center">DeepEye-SQL<br>
-                      <span class="affiliation">HKUST(GZ)</span><br><a href="https://arxiv.org/abs/2510.17586" class="paperlink">[Boyan Li et al. '25]</a>
-                    </td>
-                    <td class="align-middle text-center"><a href="https://github.com/HKUSTDial/DeepEye-SQL">[link]</a></td>
-                    <td class="align-middle text-center">27B</td>
-                    <td class="align-middle text-center">✔️</td>
-                    <td class="align-middle text-center">74.49</td>
-                    <td class="align-middle text-center">78.42</td>
-                  </tr>
-
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Jun 09, 2026</span>


### PR DESCRIPTION
## Summary

- Move the DeepEye-SQL row above Spektr-SQL in the Overall EX leaderboard.
- Preserve all leaderboard values and links unchanged.

## Why

The leaderboard is ordered by Test EX. DeepEye-SQL scores 78.42, which is higher than Spektr-SQL's 78.31, but the rows were reversed.

## Validation

- `git diff --check`
- Verified the local order: MarkovSQL 78.70, DeepEye-SQL 78.42, Spektr-SQL 78.31, and DataGallery-Text2SQL 77.53.
- Confirmed that the moved DeepEye-SQL row retains its existing values and links.
