### PR TITLE
Add AxisSQL to the Overall Leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,7 +1159,21 @@
                     <td class="align-middle text-center">75.35</td>
                     <td class="align-middle text-center">77.03</td>
                   </tr>
-					  
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Aug 03, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">AxisSQL<br>
+                      <span class="affiliation">UST</span><br>
+                    </td>
+                    <td class="align-middle text-center"><a href="https://github.com/ShaikNagurShareef/AxisSQL">[link]</a></td>
+                    <td class="align-middle text-center">31B</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">76.86</td>
+                  </tr>
+
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Jul 07, 2026</span> 
@@ -3527,6 +3541,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">14 B</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">68.67</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 03, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">AxisSQL<br>
+                        <span class="affiliation">UST</span><br>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/ShaikNagurShareef/AxisSQL">[link]</a></td>
+                      <td class="align-middle text-center">31B</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">68.35</td>
                     </tr>
 
 


### PR DESCRIPTION
## Summary
Adds one row to the Overall Leaderboard's EX and R-VES tables for **AxisSQL**, per confirmation from the BIRD Eval Team that this submission fits the Overall track.

**Official test-set results** (from BIRD's evaluation):
- EX: 76.86 (simple 85.35 / moderate 72.61 / challenging 56.84)
- Soft F1: 78.04 (simple 85.81 / moderate 73.96 / challenging 60.12)
- R-VES: 68.35 (simple 76.57 / moderate 63.68 / challenging 50.10)

- Underlying model: Gemma-4-31B (public checkpoint, no fine-tuning), 31B parameters
- Uses oracle knowledge (BIRD's `evidence` field)
- Code: https://github.com/ShaikNagurShareef/AxisSQL

## Placement
Both rows inserted in the existing descending-Test-score order:
- `ex-table`: between `SiriusAI-Text2SQL-Agent` (77.03) and `GT-ChatBI-SQL` (76.80)
- `ves-table`: between `Reasoning-SQL 14B` (68.67) and `CSC-SQL + XiYanSQL-QwenCoder-32B-2412` (67.84)

No existing rows were modified.