### PR TITLE
Add PRIME-SQL to Overall Leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1939,6 +1939,20 @@ Comprehensive National Science Center-IDATA</span><br>
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Aug 06, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">PRIME-SQL<br>
+                      <span class="affiliation">Anonymous</span>
+                    </td>
+                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">UNK</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">70.93</td>
+                    <td class="align-middle text-center">68.03</td>
+                  </tr>
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Mar 4, 2025</span>
                     </td>
                     <td class="align-middle text-center">OmniSQL-7B<br>
@@ -3809,6 +3823,18 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">UNK</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">62.43</td>
+                    </tr>
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 06, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">PRIME-SQL<br>
+                        <span class="affiliation">Anonymous</span>
+                      </td>
+                      <td class="align-middle text-center"></td>
+                      <td class="align-middle text-center">UNK</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">62.06</td>
                     </tr>
                     <tr>
                       <td scope="row" class="align-middle text-center counter-cell">


### PR DESCRIPTION
## Submission: PRIME-SQL

Adding PRIME-SQL to the **Overall Leaderboard** (both EX and R-VES tables), per confirmation from the BIRD team via email.

> **Note:** This method was previously referred to as **REACTOR_SQL**. It has been renamed to **PRIME-SQL**; both names refer to the same method/submission.

### Test set results

| Metric  | Simple | Moderate | Challenging | Total |
|---------|--------|----------|-------------|-------|
| Count   | 949    | 555      | 285         | 1789  |
| EX      | 75.34  | 64.68    | 50.18       | **68.03** |
| Soft F1 | 76.08  | 66.82    | 52.99       | **69.53** |
| R-VES   | 69.26  | 58.52    | 44.97       | **62.06** |

- Dev set EX: 70.93
- Affiliation: Anonymous
- Oracle Knowledge: ✔️
- Model size: UNK

### Changes
- `index.html`: added one row to the EX table (Overall Leaderboard) at the appropriate rank
- `index.html`: added one row to the R-VES table (Overall Leaderboard) at the appropriate rank

### Correspondence
BIRD team confirmed the submission is a fit for the Overall track and instructed to open a PR here.
