### PR TITLE
Add EGV-SQL + Qwen3.6-27B to Overall Leaderboard (EX & R-VES)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1578,6 +1578,20 @@ Comprehensive National Science Center-IDATA</span><br>
                     <td class="align-middle text-center">72.28</td>
                   </tr>
 
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Aug 17, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">EGV-SQL + Qwen3.6-27B<br>
+                      <span class="affiliation">Tampere University</span><br>
+                    </td>
+                    <td class="align-middle text-center"><a href="https://github.com/Tapsatr/EGV-SQL">[link]</a></td>
+                    <td class="align-middle text-center">27B</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">71.64</td>
+                    <td class="align-middle text-center">72.16</td>
+                  </tr>
+
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
@@ -3701,6 +3715,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">20B</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">66.25</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 17, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">EGV-SQL + Qwen3.6-27B<br>
+                        <span class="affiliation">Tampere University</span><br>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/Tapsatr/EGV-SQL">[link]</a></td>
+                      <td class="align-middle text-center">27B</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">65.90</td>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
Adds EGV-SQL + Qwen3.6-27B (Tampere University) to the Overall Leaderboard,
per confirmation from the BIRD team via email that this submission fits the
Overall track.

Official test set results (1789 questions), as reported by the BIRD team:
EX **72.16**, Soft-F1 **73.04**, R-VES **65.90**. Dev EX 71.64 on the original
dev split.

Submission reference: evaluated under evaluation type 1 (single A100 80G) with
`treprepr/qwen3.6-27b-bird-evidence-finetuned` and
`treprepr/reranker-bird-evidence-finetuned`. The submission was sent without a
method name; "EGV-SQL" names it for the leaderboard.

Code: https://github.com/Tapsatr/EGV-SQL
Models: https://huggingface.co/treprepr/qwen3.6-27b-bird-evidence-finetuned