### PR TITLE
add: RAS to overall leaderboard (EX and R-VES)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,20 @@
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Aug 19, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">RAS<br>
+                      <span class="affiliation">Adya AI</span><br>
+                    </td>
+                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">UNK</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">72.49</td>
+                    <td class="align-middle text-center">79.82</td>
+                  </tr>
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Jul 14, 2026</span>
                     </td>
                     <td class="align-middle text-center">DeepEye<br>
@@ -3262,6 +3276,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">UNK</td>
                       <td class="align-middle text-center">✔️</td>
                       <td class="align-middle text-center">76.31</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 19, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">RAS<br>
+                        <span class="affiliation">Adya AI</span><br>
+                      </td>
+                      <td class="align-middle text-center"></td>
+                      <td class="align-middle text-center">UNK</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">74.95</td>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
Adding RAS to the overall track following our test-set evaluation by the BIRD team.

- EX: 79.82 (test), 72.49 (dev)
- R-VES: 74.95 (test)

Results received from the BIRD team on Aug 19, 2026. The method is a single-model agentic loop — API-based, with no GPU, no fine-tuning, and no ensemble or candidate reranking, so Size is listed as UNK. Oracle knowledge (evidence) is used.

Two rows were added, one to each of the EX and R-VES tables in the overall leaderboard. No existing entries were modified.