### PR TITLE
Add Qwen3.5-2B + StructCoT Distillation (test EX 68.47) to overall and single-model leaderboards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1967,6 +1967,20 @@ Comprehensive National Science Center-IDATA</span><br>
 
                   <tr>
                       <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">Qwen3.5-2B + StructCoT Distillation (SC@7)<br>
+                        <span class="affiliation">Alio Leuchtmann</span>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://huggingface.co/AlioLeuchtmann/qwen-3.5-sql-27B-Distill-2B">[link]</a></td>
+                      <td class="align-middle text-center">2B</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center"><span class="new-dev-badge" data-tooltip="Evaluated on BIRD Dev 20251106">New Dev</span><br>61.40</td>
+                      <td class="align-middle text-center"><span class="new-dev-badge" style="visibility:hidden">New Dev</span><br>68.47</td>
+                    </tr>
+
+                  <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
                         <span class="badge badge-secondary">Feb 21, 2026</span>
                       </td>
                       <td class="align-middle text-center">Qwen3-Coder-480B-A35B<br>
@@ -5040,6 +5054,22 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center"></td>
                       <td class="align-middle text-center">68.51</td>
                       <td class="align-middle text-center">68.53</td>
+                    </tr>
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">Qwen3.5-2B + StructCoT Distillation<br>
+                        <span class="affiliation">Alio Leuchtmann</span>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://huggingface.co/AlioLeuchtmann/qwen-3.5-sql-27B-Distill-2B">[link]</a></td>
+                      <td class="align-middle text-center">2B</td>
+                      <td class="align-middle text-center"
+    style="font-size: 0.95em; font-style: italic;">Few
+</td>
+                      <td class="align-middle text-center"><span class="new-dev-badge" data-tooltip="Evaluated on BIRD Dev 20251106">New Dev</span><br>61.40</td>
+                      <td class="align-middle text-center"><span class="new-dev-badge" style="visibility:hidden">New Dev</span><br>68.47</td>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
Adding our evaluated submission per the BIRD team's test-set evaluation (received Aug 24, 2026):

**Qwen3.5-2B + StructCoT Distillation (self-consistency @7)** — Alio Leuchtmann

- Test EX **68.47** (simple 77.13 / moderate 62.70 / challenging 50.88), Soft F1 69.41, R-VES 61.49
- Dev (BIRD Dev 20251106) EX 61.40 (maj@7)
- Size: **2B** · Self-Consistency: Few (1 greedy + 6 samples)
- Model: https://huggingface.co/AlioLeuchtmann/qwen-3.5-sql-27B-Distill-2B

Rows added to both the overall and single-model leaderboards (the evaluation email confirmed the submission fits both tracks), inserted in test-EX order.