### PR TITLE
Add sqlpup (394M, from scratch) to the EX and Single Trained Model leaderboards

### DIFF
--- a/index.html
+++ b/index.html
@@ -3231,7 +3231,33 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">6.32</td>
                       <td class="align-middle text-center">7.06</td>
                     </tr>
-                  </tbody>
+                              <tr>
+              <td scope="row" class="align-middle text-center counter-cell">
+                <span class="badge badge-secondary">Aug 24, 2026</span>
+              </td>
+              <td class="align-middle text-center">sqlpup (7-sample vote)<br>
+                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+              </td>
+              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+              <td class="align-middle text-center">394M</td>
+              <td class="align-middle text-center">✔️</td>
+              <td class="align-middle text-center">23.51</td>
+              <td class="align-middle text-center">33.15</td>
+            </tr>
+            <tr>
+              <td scope="row" class="align-middle text-center counter-cell">
+                <span class="badge badge-secondary">Aug 24, 2026</span>
+              </td>
+              <td class="align-middle text-center">sqlpup (single pass)<br>
+                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+              </td>
+              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+              <td class="align-middle text-center">394M</td>
+              <td class="align-middle text-center">✔️</td>
+              <td class="align-middle text-center">19.23</td>
+              <td class="align-middle text-center">27.33</td>
+            </tr>
+</tbody>
                 </table>
               </div>
             </div>
@@ -5748,7 +5774,33 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">6.32</td>
                       <td class="align-middle text-center">7.06</td>
                     </tr>
-                  </tbody>
+                              <tr>
+              <td scope="row" class="align-middle text-center counter-cell">
+                <span class="badge badge-secondary">Aug 24, 2026</span>
+              </td>
+              <td class="align-middle text-center">sqlpup (7-sample vote)<br>
+                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+              </td>
+              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+              <td class="align-middle text-center">394M</td>
+              <td class="align-middle text-center">Few</td>
+              <td class="align-middle text-center">23.51</td>
+              <td class="align-middle text-center">33.15</td>
+            </tr>
+            <tr>
+              <td scope="row" class="align-middle text-center counter-cell">
+                <span class="badge badge-secondary">Aug 24, 2026</span>
+              </td>
+              <td class="align-middle text-center">sqlpup (single pass)<br>
+                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+              </td>
+              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+              <td class="align-middle text-center">394M</td>
+              <td class="align-middle text-center"></td>
+              <td class="align-middle text-center">19.23</td>
+              <td class="align-middle text-center">27.33</td>
+            </tr>
+</tbody>
                 </table>
               </div>
             </div>


### PR DESCRIPTION
Adding my evaluated submission per the BIRD team's test-set evaluation (received Aug 24, 2026):

sqlpup — 394M text-to-SQL model pretrained from scratch — Shiven Khurdi

7-sample execution-guided voting
  Test EX 33.15 (simple 36.99 / moderate 33.51 / challenging 19.65), Soft F1 33.78, R-VES 29.94
  Dev EX 23.51

Single pass (no test-time compute)
  Test EX 27.33 (simple 31.61 / moderate 26.31 / challenging 15.09), Soft F1 27.90, R-VES 24.95
  Dev EX 19.23

Size: 394M · Self-Consistency: Few (7 samples, execution-guided voting)
Both rows are the same checkpoint, differing only in whether voting runs on top.

Code: https://github.com/shivenkk/sqlpup
Model: https://huggingface.co/shivenkk/sqlpup-394m-sft-grpo

Corpus, tokenizer, architecture and training loop all built from scratch for this
task: no pretrained initialisation, no distillation. The score is not competitive
and is not intended to be; it is a from-scratch datapoint at a scale the
leaderboard does not currently cover.

Rows added to both the overall and single-model leaderboards (the evaluation email
confirmed the submission fits both tracks), inserted in test-EX order.