### PR TITLE
Sort the sqlpup rows into test-EX order

### DIFF
--- a/index.html
+++ b/index.html
@@ -3020,7 +3020,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">34.35</td>
                       <td class="align-middle text-center">36.47</td>
                     </tr>
-
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">sqlpup (7-sample vote)<br>
+                        <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+                      <td class="align-middle text-center">394M</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">23.51</td>
+                      <td class="align-middle text-center">33.15</td>
+                    </tr>
                     <tr>
                       <td
                         scope="row"
@@ -3073,7 +3085,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">25.88</td>
                       <td class="align-middle text-center">28.95</td>
                     </tr>
-
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">sqlpup (single pass)<br>
+                        <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+                      <td class="align-middle text-center">394M</td>
+                      <td class="align-middle text-center">✔️</td>
+                      <td class="align-middle text-center">19.23</td>
+                      <td class="align-middle text-center">27.33</td>
+                    </tr>
                     <!-- Copy from here -->
                     <tr>
                       <td
@@ -3243,32 +3267,6 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">6.32</td>
                       <td class="align-middle text-center">7.06</td>
                     </tr>
-                              <tr>
-              <td scope="row" class="align-middle text-center counter-cell">
-                <span class="badge badge-secondary">Aug 24, 2026</span>
-              </td>
-              <td class="align-middle text-center">sqlpup (7-sample vote)<br>
-                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
-              </td>
-              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
-              <td class="align-middle text-center">394M</td>
-              <td class="align-middle text-center">✔️</td>
-              <td class="align-middle text-center">23.51</td>
-              <td class="align-middle text-center">33.15</td>
-            </tr>
-            <tr>
-              <td scope="row" class="align-middle text-center counter-cell">
-                <span class="badge badge-secondary">Aug 24, 2026</span>
-              </td>
-              <td class="align-middle text-center">sqlpup (single pass)<br>
-                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
-              </td>
-              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
-              <td class="align-middle text-center">394M</td>
-              <td class="align-middle text-center">✔️</td>
-              <td class="align-middle text-center">19.23</td>
-              <td class="align-middle text-center">27.33</td>
-            </tr>
 </tbody>
                 </table>
               </div>
@@ -5627,7 +5625,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">34.35</td>
                       <td class="align-middle text-center">36.47</td>
                     </tr>
-
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">sqlpup (7-sample vote)<br>
+                        <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+                      <td class="align-middle text-center">394M</td>
+                      <td class="align-middle text-center">Few</td>
+                      <td class="align-middle text-center">23.51</td>
+                      <td class="align-middle text-center">33.15</td>
+                    </tr>
                     <tr>
                       <td
                         scope="row"
@@ -5653,7 +5663,19 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">27.38</td>
                       <td class="align-middle text-center">33.04</td>
                     </tr>
-
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Aug 24, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">sqlpup (single pass)<br>
+                        <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
+                      </td>
+                      <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
+                      <td class="align-middle text-center">394M</td>
+                      <td class="align-middle text-center"></td>
+                      <td class="align-middle text-center">19.23</td>
+                      <td class="align-middle text-center">27.33</td>
+                    </tr>
                     <tr>
                       <td
                         scope="row"
@@ -5821,32 +5843,6 @@ Comprehensive National Science Center-IDATA</span><br>
                       <td class="align-middle text-center">6.32</td>
                       <td class="align-middle text-center">7.06</td>
                     </tr>
-                              <tr>
-              <td scope="row" class="align-middle text-center counter-cell">
-                <span class="badge badge-secondary">Aug 24, 2026</span>
-              </td>
-              <td class="align-middle text-center">sqlpup (7-sample vote)<br>
-                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
-              </td>
-              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
-              <td class="align-middle text-center">394M</td>
-              <td class="align-middle text-center">Few</td>
-              <td class="align-middle text-center">23.51</td>
-              <td class="align-middle text-center">33.15</td>
-            </tr>
-            <tr>
-              <td scope="row" class="align-middle text-center counter-cell">
-                <span class="badge badge-secondary">Aug 24, 2026</span>
-              </td>
-              <td class="align-middle text-center">sqlpup (single pass)<br>
-                <a href="https://github.com/shivenkk/sqlpup" class="paperlink">[Shiven Khurdi '26]</a>
-              </td>
-              <td class="align-middle text-center"><a href="https://github.com/shivenkk/sqlpup">[link]</a></td>
-              <td class="align-middle text-center">394M</td>
-              <td class="align-middle text-center"></td>
-              <td class="align-middle text-center">19.23</td>
-              <td class="align-middle text-center">27.33</td>
-            </tr>
 </tbody>
                 </table>
               </div>


### PR DESCRIPTION
Follow-up to #221. The two sqlpup rows were appended at the end of each
EX tbody rather than inserted in sorted position, so they rendered below
entries scoring as low as 7.06.

This moves them into test-EX descending order in both tables:
- Leaderboard - Execution Accuracy (EX): vote 33.15 between Codex 36.47
  and Palm-2 33.04; single pass 27.33 between ChatGPT + CoT 28.95 and
  ChatGPT 26.77
- Single Trained Model Track: vote 33.15 between Codex 36.47 and Palm-2
  33.04; single pass 27.33 between Palm-2 33.04 and ChatGPT 26.77

No values, links, or column entries changed. Pure row move plus
indentation normalized to match the surrounding rows.