### PR TITLE
Add ELG-SQL results to BIRD leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1454,6 +1454,20 @@ Comprehensive National Science Center-IDATA</span><br>
 
                   <tr>
                     <td scope="row" class="align-middle text-center counter-cell">
+                      <span class="badge badge-secondary">Sep 02, 2026</span>
+                    </td>
+                    <td class="align-middle text-center">ELG-SQL<br>
+                      <span class="affiliation">AMS CIR</span>
+                    </td>
+                    <td class="align-middle text-center"></td>
+                    <td class="align-middle text-center">32B</td>
+                    <td class="align-middle text-center">✔️</td>
+                    <td class="align-middle text-center">73.40</td>
+                    <td class="align-middle text-center">74.51</td>
+                  </tr>
+
+                  <tr>
+                    <td scope="row" class="align-middle text-center counter-cell">
                       <span class="badge badge-secondary">Sep 10, 2025</span>
                     </td>
                     <td class="align-middle text-center">JT-SQLAgent<br>
@@ -4781,6 +4795,20 @@ Comprehensive National Science Center-IDATA</span><br>
                     </tr>
 
 
+
+                    <tr>
+                      <td scope="row" class="align-middle text-center counter-cell">
+                        <span class="badge badge-secondary">Sep 02, 2026</span>
+                      </td>
+                      <td class="align-middle text-center">ELG-SQL<br>
+                        <span class="affiliation">AMS CIR</span>
+                      </td>
+                      <td class="align-middle text-center"><a></a></td>
+                      <td class="align-middle text-center">32B</td>
+                      <td class="align-middle text-center" style="font-size: 0.95em; font-style: italic;">Many</td>
+                      <td class="align-middle text-center">73.40</td>
+                      <td class="align-middle text-center">74.51</td>
+                    </tr>
 
                     <tr>
                       <td scope="row" class="align-middle text-center counter-cell">


### PR DESCRIPTION
This PR adds ELG-SQL to both the Overall Leaderboard and the Single Trained Model Track.

Submission details:
- Team/Affiliation: AMS CIR
- Model size: 32B
- Dev EX: 73.40
- Test EX: 74.51
- Oracle Knowledge: Yes
- Self-Consistency: Many, 16 SQL candidates

According to our previous discussion with the BIRD team, this submission fits both the overall and single-model tracks.